### PR TITLE
Fix for DHT11

### DIFF
--- a/esp8266/dht_esp8266.lua
+++ b/esp8266/dht_esp8266.lua
@@ -42,7 +42,8 @@ function transmit_msg(data)
 end
 
 function readDHTValues()
-    status, temp, humi, temp_dec, humi_dec = dht.read(DHT_PIN)
+    status, temp, humi, temp_dec, humi_dec = dht.read(DHT_PIN) --DHT22
+   -- status, temp, humi, temp_dec, humi_dec = dht.read11(DHT_PIN) --DHT11
     if status == dht.OK then
         return {temperature= temp, humidity= humi}    
     else


### PR DESCRIPTION
**If you read data using an DHT11 with following line then you get too high values:**     local status, temp, humi, temp_dec, humi_dec = dht.read(DHT_PIN)

**But if you use following line, you get the real values:**     local status, temp, humi, temp_dec, humi_dec = dht.read11(DHT_PIN)

